### PR TITLE
Expand Python requirements to match v0.9.1 pyproject.toml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,16 +12,16 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:
-    - python >=3.9,<3.11
+    - python >=3.9,<3.13
     - poetry-core >=1.0.0
     - setuptools
     - pip
   run:
-    - python >=3.9.0,<3.11
+    - python >=3.9,<3.13
     - h5py >=3.2.1,<4.0.0
     - numpy >=1.26,<1.27.0
     - pillow >=10.3.0,<10.4.0


### PR DESCRIPTION
Updating meta.yaml to include up to Python 3.12, as per https://github.com/MiraGeoscience/geoh5py/blob/v0.9.1/pyproject.toml

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] ~~Reset the build number to `0` (if the version changed)~~
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
